### PR TITLE
fix Deprecation Count

### DIFF
--- a/lib/mongoose-datatables.js
+++ b/lib/mongoose-datatables.js
@@ -79,7 +79,7 @@ function dataTablesPlugin (schema, options) {
       }
 
       Promise
-        .all([query.exec(), thisSchema.count(find)])
+        .all([query.exec(), thisSchema.countDocuments(find)])
         .then(function (results) {
           var response = {}
           response[totalKey] = results[1]


### PR DESCRIPTION
**Solution to fix error**

Error:
> (node:17492) DeprecationWarning: collection.count is deprecated, and will be removed in a future version. Use collection.countDocuments or collection.estimatedDocumentCount instead

