### PR TITLE
Added support for sort column

### DIFF
--- a/lib/mongoose-datatables.js
+++ b/lib/mongoose-datatables.js
@@ -25,24 +25,43 @@ function dataTablesPlugin (schema, options) {
     var columns = params.columns || [];
     var formatter = params.formatter
 
+    var findGlobal = []
     if (search && search.value && search.fields && search.fields.length) {
       var searchQuery = {
         '$regex': search.value,
         '$options': 'i'
       }
-
-      if (search.fields.length == 1) {
-        find[search.fields[0]] = searchQuery
-      } else if(search.fields.length > 1) {
-        if (!find.$or) {
-          find.$or = []
-        }
-        search.fields.forEach(function (el){
+      
+      if(search.fields.length >= 1) {
+        search.fields.forEach(function (field){
           var obj = {}
-          obj[el] = searchQuery
-          find.$or.push(obj)
+          obj[field] = searchQuery
+          findGlobal.push(obj)
         })
       }
+    }
+
+    var findColumn = []
+    if (columns && columns.length>=1) {
+      columns.forEach(function(col){
+        if (col.value) {
+          col.fields.forEach(function (field){
+            var obj = {}
+            obj[field] = col.value
+            findColumn.push(obj)
+          })
+        }
+      })
+    }
+
+    if (findGlobal.length>0 && findColumn.length>0) {
+      find.$and = [];
+      find.$and.push({$or:findGlobal})
+      find.$and.push({$and:findColumn})
+    } else if (findGlobal.length>0) {
+      find = {$or:findGlobal}
+    } else if (findColumn.length>0) {
+      find = {$and:findColumn}
     }
 
     if (order && columns) {


### PR DESCRIPTION
Add support for sort column like this 
dataTable.columns(3).search( keyword ).draw();

code on nodejs back-end will be like this

    Order.dataTables({
        limit: req.body.length,
        skip: req.body.start,
        search: {
            value: req.body.search.value,
            fields: ["order_no", "store_name", "vehicle_code"]
        },
        columns: [{
            value: req.body.columns[3].search.value,
            fields: ["zone"]
        }],
        sort: sortColumn(req.body,["order_no","order_date","zone","store_name","total_amount","vehicle_code","order_status"])
    }).then(function (table) {
        .....
    })