### PR TITLE
enable removal of 'insensitive' regex flag

### DIFF
--- a/lib/mongoose-datatables.js
+++ b/lib/mongoose-datatables.js
@@ -31,6 +31,8 @@ function dataTablesPlugin (schema, options) {
         '$options': 'i'
       }
 
+      if(search.disableInsensitiveRegex) delete searchQuery.$options;
+
       if (search.fields.length == 1) {
         find[search.fields[0]] = searchQuery
       } else if(search.fields.length > 1) {


### PR DESCRIPTION
if the fields to be searched by the regex contain Number or a non-latin-characters of a String a case-insensitive regex search decreases indexed searches performance. This PR adds the ability to choose when to remove in "insensitive" setting of the regex search.